### PR TITLE
Fixed #categoriesTable onclick bug

### DIFF
--- a/resources/js/categories.js
+++ b/resources/js/categories.js
@@ -39,7 +39,7 @@ window.addEventListener('DOMContentLoaded', function () {
             get(`/categories/${ categoryId }`)
                 .then(response => response.json())
                 .then(response => openEditCategoryModal(editCategoryModal, response))
-        } else {
+        } else if (deleteBtn) {
             const categoryId = deleteBtn.getAttribute('data-id')
 
             if (confirm('Are you sure you want to delete this category?')) {


### PR DESCRIPTION
We are checking if "editBtn" is not null and executing if block and that is fine. However, the else block assumes that clicked element is always the "deleteBtn" which is incorrect. The else block executes if we click on blank space of any category it will call .getAttribute() on null, then try to make a request that. Also, this error will show up in js console.