### PR TITLE
Clear the field value of upload receipt and import transactions when open the modal

### DIFF
--- a/resources/js/transactions.js
+++ b/resources/js/transactions.js
@@ -205,6 +205,10 @@ window.addEventListener('DOMContentLoaded', function () {
             })
     })
 
+    document.getElementById('importTransactionsBtn').addEventListener('click', function (event) {
+        importTransactionsModal._element.querySelector('input[type="file"]').value = '';
+    });
+
     document.querySelector('.import-transactions-btn').addEventListener('click', function (event) {
         const formData = new FormData()
         const button   = event.currentTarget

--- a/resources/js/transactions.js
+++ b/resources/js/transactions.js
@@ -134,6 +134,7 @@ window.addEventListener('DOMContentLoaded', function () {
                 })
             }
         } else if (uploadReceiptBtn) {
+            uploadReceiptModal._element.querySelector('input[type="file"]').value = '';
             const transactionId = uploadReceiptBtn.getAttribute('data-id')
 
             uploadReceiptModal._element

--- a/resources/views/transactions/index.twig
+++ b/resources/views/transactions/index.twig
@@ -15,7 +15,7 @@
 {% block content %}
     <div class="transactions container content-body">
         <div class="text-end mb-4">
-            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#importTransactionsModal">
+            <button type="button" id="importTransactionsBtn" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#importTransactionsModal">
                 <i class="bi bi-plus-circle me-1"></i>
                 Import Transactions
             </button>


### PR DESCRIPTION
When we open the upload receipt and import transactions modal, upload a file, and reopen the modal again, we will notice that the field is not empty.